### PR TITLE
Atualizando imagem de fundo da capa

### DIFF
--- a/fixos/customizacoes.sty
+++ b/fixos/customizacoes.sty
@@ -52,12 +52,12 @@
 %		\textbf{\textsc{Trabalho de Conclusão de Curso}}
 %	\end{huge}
 
-    \vspace*{2.7in}
+    \vspace*{2.9in}
 	{\textbf{\large\imprimirinstituicao}}
 	\par
 	{\textbf{\large\imprimircurso}}
 
-	\vspace{0.5in}
+	\vspace{1.5in}
 
     {\ABNTEXchapterfont\bfseries\LARGE\imprimirtitulo}
     \vspace*{\fill}
@@ -73,7 +73,7 @@
     \par
     \textbf{{\large\imprimirdata}}
     
-    \vspace*{2.2in}
+    \vspace*{1in}
   \end{capa}
 }
 


### PR DESCRIPTION
A capa anterior utilizava cores e formas diferentes das originais da UnB. Para esse PR eu utilizei uma imagem provido pelo professor Cristiano Jacques Miosso Mendes.

Comparação:

**Antiga**
![old](https://user-images.githubusercontent.com/20938712/66008230-dd8b6d00-e48b-11e9-93d3-1ff0c91b5ce9.jpg)

**Nova**
![new](https://user-images.githubusercontent.com/20938712/66008277-057ad080-e48c-11e9-93f0-26e71e91fdf2.jpg)


**OBS:** A nova imagem não é exatamente igual a anterior, então os textos centrais não ficaram centralizados por padrão. 

Eu posso centraliza-los, porém não sei se os valores definidos no script são provenientes da ABNT ou algo assim. Posso alterá-los?

