### PR TITLE
fix: atualiza Dockerfile e docker-compose para compatibilidade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ghostscript texlive-publishers texlive-lang-portuguese texlive-latex-extra texlive-fonts-recommended make
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
     latex:
       build:


### PR DESCRIPTION
- Removido o campo `version` do docker-compose.yml, que estava obsoleto.
- Debian Buster está fora de suporte, não há resposta dos repositórios mais. Migrado para bookworm (Debian 12).
